### PR TITLE
stats: remove required annotation from sent_at field

### DIFF
--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -263,7 +263,7 @@ message StatsUploadRequest {
   // Used by the server to detect clients with skewed clocks.
   // The idea is that upon receiving the stats payload, the server's current time should be close to this
   // value.
-  google.protobuf.Timestamp sent_at = 3 [(validate.rules).message = {required: true}];
+  google.protobuf.Timestamp sent_at = 3;
 }
 
 message StatsUploadResponse {


### PR DESCRIPTION
The field cannot be required as there are old clients that do not know about it and we still want to accept payloads from them.