### PR TITLE
filters: add field_type field

### DIFF
--- a/src/bitdrift_public/protobuf/filter/v1/filter.proto
+++ b/src/bitdrift_public/protobuf/filter/v1/filter.proto
@@ -64,7 +64,7 @@ message Filter {
 
       string name = 1 [(validate.rules).string = {min_len: 1}];
       string value = 2 [(validate.rules).string = {min_len: 1}];
-      FieldType field_type = 3 [(validate.rules).enum = {defined_only : true not_in : 0}];
+      FieldType field_type = 3 [(validate.rules).enum = {defined_only: true not_in: 0}];
     }
   }
 


### PR DESCRIPTION
Make the API less error prone and more explicit by adding `field_type` field as opposed to relying on a bunch of implicit rules for determining the type of the final field.