### PR TITLE
rename ScrubField transform, better docs

### DIFF
--- a/src/bitdrift_public/protobuf/filter/v1/filter.proto
+++ b/src/bitdrift_public/protobuf/filter/v1/filter.proto
@@ -79,7 +79,7 @@ message Filter {
       bool allow_override = 4;
     }
 
-    // Removes a field with the specified name from the list of captured or matching fields. 
+    // Removes a field with the specified name from the list of captured or matching fields.
     // If the field doesn't exist, no action is taken.
     message RemoveField {
       // The name of the field to remove.


### PR DESCRIPTION
1. Move `ScrubField` transform to "transform" namespace.
2. Renamed `ScrubField` to `RegexMatchAndSubstitute` as the latter is a better description of what the transform actually does.