### PR TITLE
metrics: swap ready_to_upload with period_end in index

### DIFF
--- a/src/bitdrift_public/protobuf/client/v1/metric.proto
+++ b/src/bitdrift_public/protobuf/client/v1/metric.proto
@@ -20,8 +20,10 @@ message PendingAggregationIndex {
     string name = 1;
     // The start of the period that this file covers. All metrics are aggregated over this period.
     google.protobuf.Timestamp period_start = 2;
-    // True if an aggregation is ready to upload and should no longer be written to.
-    bool ready_to_upload = 3;
+    // When the aggregation was closed. If specified, the server can decide to handle variable
+    // size aggregation windows by averaging the data over the period or some other heuristic. Also
+    // indicates that the file is ready for upload.
+    google.protobuf.Timestamp period_end = 3;
   }
   // List of files, in order of period_start, that are pending upload.
   repeated PendingFile pending_files = 1;


### PR DESCRIPTION
It's redundant and this will make the logic simpler.