### PR TITLE
metrics: better support for workflow metrics

### DIFF
--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -374,6 +374,9 @@ message StatsUploadRequest {
       // recorded.
       Aggregated aggregated = 2;
     }
+
+    // A map of metric ID to any cardinality overflows that occurred during this snapshot interval.
+    map<string, uint64> metric_id_overflows = 3;
   }
 
   // A collection of stats snapshots to be recorded by the backend.

--- a/src/bitdrift_public/protobuf/client/v1/metric.proto
+++ b/src/bitdrift_public/protobuf/client/v1/metric.proto
@@ -56,8 +56,13 @@ message InlineHistogramValues {
 }
 
 message Metric {
-  // Unique name of this metric.
-  string name = 1 [(validate.rules).string = {min_len: 1}];
+  oneof metric_name_type {
+    // Unique name of this metric. This is used for global metrics.
+    string name = 1;
+
+    // The ID of the metric, if applicable. This is used for workflow scoped metrics.
+    string metric_id = 7;
+  }
 
   // Tags associated with this metric.
   map<string, string> tags = 2;


### PR DESCRIPTION
1) Move away from using the _id in the tag hack. Workflow metrics
   are now first class.
2) Report explicit overflows on a per metric/action ID basis. This
   allows cardinality limits to be scoped to individual action IDs
   versus being global.