### PR TITLE
add artifact metadata

### DIFF
--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -270,6 +270,10 @@ message UploadArtifactRequest {
   // A client-generated ID that uniquely identifies the artifact being uploaded. This is used to correlate
   // the artifact with logs that reference it.
   string artifact_id = 4 [(validate.rules).string = {min_len: 1}];
+
+  // An optional set of key-value data indicating the state of the device at the time of artifact emission. For example,
+  // this may capture information about the device at the time of a crash.
+  map<string, bitdrift_public.protobuf.logging.v1.Data> state_metadata = 5;
 }
 
 message UploadArtifactResponse {

--- a/src/bitdrift_public/protobuf/client/v1/artifact.proto
+++ b/src/bitdrift_public/protobuf/client/v1/artifact.proto
@@ -8,6 +8,7 @@
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
+import "bitdrift_public/protobuf/logging/v1/payload.proto";
 
 package bitdrift_public.protobuf.client.v1;
 

--- a/src/bitdrift_public/protobuf/client/v1/artifact.proto
+++ b/src/bitdrift_public/protobuf/client/v1/artifact.proto
@@ -23,6 +23,11 @@ message ArtifactUploadIndex {
     // in us rejecting the upload, the artifact will be removed from the local cache, so
     // this being true means that the file should be uploaded.
     bool pending_intent_negotiation = 3;
+
+    // An optional set of key-value data indicating the state of the device at the time of artifact emission. For example, this may capture information about the device at the time of a crash.
+    // This is stored outside of the artifact itself to be compatible with opaque uploads where storing this metadata
+    // within the artifact is not possible.
+    map<string, bitdrift_public.protobuf.logging.v1.Data> state_metadata = 5;
   }
 
   // List of files, in order of time, that are pending upload.


### PR DESCRIPTION
Make it possible to store arbitrary metadata outside of the artifact that is uploaded alongside the data.