### PR TITLE
allow passing feature flags along with artifact uploads

### DIFF
--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -15,6 +15,7 @@ import "bitdrift_public/protobuf/filter/v1/filter.proto";
 import "bitdrift_public/protobuf/workflow/v1/workflow.proto";
 import "bitdrift_public/protobuf/bdtail/v1/bdtail_config.proto";
 import "bitdrift_public/protobuf/config/v1/config.proto";
+import "bitdrift_public/protobuf/client/v1/feature_flag.proto";
 import "bitdrift_public/protobuf/logging/v1/payload.proto";
 import "validate/validate.proto";
 
@@ -271,17 +272,6 @@ message UploadArtifactIntentResponse {
     // The candidate artifact should be dropped.
     Drop drop = 4;
   }
-}
-
-message FeatureFlag {
-  // The name of the feature flag.
-  string name = 1 [(validate.rules).string = {min_len: 1}];
-
-  // The variant of the feature flag, if any.
-  optional string variant = 2;
-
-  // The last time the feature flag was updated.
-  google.protobuf.Timestamp last_updated = 3 [(validate.rules).message = {required: true}];
 }
 
 message UploadArtifactRequest {

--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -273,6 +273,17 @@ message UploadArtifactIntentResponse {
   }
 }
 
+message FeatureFlag {
+  // The name of the feature flag.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The variant of the feature flag, if any.
+  optional string variant = 2;
+
+  // The last time the feature flag was updated.
+  google.protobuf.Timestamp last_updated = 3 [(validate.rules).message = {required: true}];
+}
+
 message UploadArtifactRequest {
   // Upload UUID used to provide idempotence and to correlate a response with this request.
   string upload_uuid = 1 [(validate.rules).string = {min_len: 1}];
@@ -296,6 +307,9 @@ message UploadArtifactRequest {
 
   // The session ID associated with the artifact.
   string session_id = 7 [(validate.rules).string = {min_len: 1}];
+
+  // The set of feature flags that were active at the time of artifact emission.
+  repeated FeatureFlag feature_flags = 8;
 }
 
 message UploadArtifactResponse {

--- a/src/bitdrift_public/protobuf/client/v1/artifact.proto
+++ b/src/bitdrift_public/protobuf/client/v1/artifact.proto
@@ -9,6 +9,7 @@ syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 import "bitdrift_public/protobuf/logging/v1/payload.proto";
+import "bitdrift_public/protobuf/client/v1/feature_flag.proto";
 
 package bitdrift_public.protobuf.client.v1;
 
@@ -31,6 +32,8 @@ message ArtifactUploadIndex {
     map<string, bitdrift_public.protobuf.logging.v1.Data> state_metadata = 5;
 
     string session_id = 6;
+
+    repeated FeatureFlag feature_flags = 7;
   }
 
   // List of files, in order of time, that are pending upload.

--- a/src/bitdrift_public/protobuf/client/v1/feature_flag.proto
+++ b/src/bitdrift_public/protobuf/client/v1/feature_flag.proto
@@ -1,0 +1,23 @@
+// api - bitdrift's client/server API definitions
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code and APIs are governed by a source available license that can be found in
+// the LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "validate/validate.proto";
+
+package bitdrift_public.protobuf.client.v1;
+message FeatureFlag {
+  // The name of the feature flag.
+  string name = 1 [(validate.rules).string = {min_len: 1}];
+
+  // The variant of the feature flag, if any.
+  optional string variant = 2;
+
+  // The last time the feature flag was updated.
+  google.protobuf.Timestamp last_updated = 3 [(validate.rules).message = {required: true}];
+}


### PR DESCRIPTION
This should make it easier for the client to send this without having to modify the report generated by the platform layer