### PR TITLE
remove pgv validation from feature flag name

### DIFF
--- a/src/bitdrift_public/protobuf/client/v1/feature_flag.proto
+++ b/src/bitdrift_public/protobuf/client/v1/feature_flag.proto
@@ -13,7 +13,7 @@ import "google/protobuf/timestamp.proto";
 import "validate/validate.proto";
 message FeatureFlag {
   // The name of the feature flag.
-  string name = 1 [(validate.rules).string = {min_len: 1}];
+  string name = 1;
 
   // The variant of the feature flag, if any.
   optional string variant = 2;


### PR DESCRIPTION
The clients allows setting this to empty so we shouldn't block this at the transport level

BIT-8278