### PR TITLE
[BIT-9016] Proposal: include all possible information in report

### DIFF
--- a/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
+++ b/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
@@ -467,10 +467,6 @@ table AndroidNativeCrash {
 
     // Additional native crash causes or summaries emitted by the platform
     causes:[string];
-
-    // Arbitrary structured native details that do not yet have first-class
-    // schema fields
-    details:[common.v1.Field];
 }
 
 // Android StrictMode violation information captured when the SDK reports a
@@ -484,9 +480,6 @@ table AndroidStrictModeViolation {
 
     // The message or summary associated with the violation
     message:string;
-
-    // Additional structured StrictMode metadata emitted by the reporter.
-    details:[common.v1.Field];
 }
 
 // Android ANR information captured from ANR diagnostics or equivalent sources
@@ -502,9 +495,6 @@ table AndroidAnr {
 
     // The ANR explanation or message provided by the platform
     message:string;
-
-    // Additional structured ANR metadata emitted by the reporter
-    details:[common.v1.Field];
 }
 
 table AndroidCrashDetails {

--- a/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
+++ b/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
@@ -409,9 +409,7 @@ table MachException {
 
 table PosixSignal {
     number:int32;
-    name:string;
     code:int32;
-    code_name:string;
     errno:int32;
     has_fault_address:bool;
     fault_address:uint64;
@@ -452,8 +450,68 @@ table AppleCrashDetails {
     termination:AppleTermination;
 }
 
+// JVM exception information captured by Android's uncaught exception handling
+table AndroidJVMCrash {
+    // The Java/Kotlin exception chain associated with the crash.
+    exceptions:[Error];
+}
+
+// Native Android crash information captured from tombstones or equivalent
+// crash-reporting sources
+table AndroidNativeCrash {
+    // The terminating signal, if one was reported for the native crash
+    signal:PosixSignal;
+
+    // The native abort message, if one was emitted by the runtime
+    abort_message:string;
+
+    // Additional native crash causes or summaries emitted by the platform
+    causes:[string];
+
+    // Arbitrary structured native details that do not yet have first-class
+    // schema fields
+    details:[common.v1.Field];
+}
+
+// Android StrictMode violation information captured when the SDK reports a
+// StrictMode issue.
+table AndroidStrictModeViolation {
+    // The StrictMode policy in effect when the violation occurred
+    policy:string;
+
+    // The violation class/category reported by StrictMode
+    violation_type:string;
+
+    // The message or summary associated with the violation
+    message:string;
+
+    // Additional structured StrictMode metadata emitted by the reporter.
+    details:[common.v1.Field];
+}
+
+// Android ANR information captured from ANR diagnostics or equivalent sources
+table AndroidAnr {
+    // The platform-reported ANR reason or category
+    reason:string;
+
+    // The activity or component implicated in the ANR, if reported
+    activity:string;
+
+    // The process/app state associated with the ANR
+    state:string;
+
+    // The ANR explanation or message provided by the platform
+    message:string;
+
+    // Additional structured ANR metadata emitted by the reporter
+    details:[common.v1.Field];
+}
+
 table AndroidCrashDetails {
-    // TBD
+    jvm:AndroidJVMCrash;
+    native:AndroidNativeCrash;
+    strict_mode:AndroidStrictModeViolation;
+    anr:AndroidAnr;
 }
 
 union CrashInfoDetails {

--- a/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
+++ b/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
@@ -59,6 +59,23 @@ enum ErrorRelation : int8 {
     CausedBy = 1,
 }
 
+// Where crash evidence was collected relative to the crashing process.
+enum CrashReporterScope : int8 {
+    Unknown = 0,
+    InProcess,
+    OutOfProcess,
+}
+
+// The concrete implementation that collected a crash observation.
+enum CrashReporter : int8 {
+    Unknown = 0,
+    AppleMetricKit,
+    AppleKSCrash,
+    AppleBitdriftCrashReporter,
+    AndroidUncaughtExceptionHandler,
+    AndroidApplicationExitInfo,
+}
+
 enum PowerState : int8 {
     Unknown = 0,
     RunningOnBattery,
@@ -378,6 +395,93 @@ table Error {
     relation_to_next:ErrorRelation = CausedBy;
 }
 
+table NSException {
+    name:string;
+    reason:string;
+    user_info:[common.v1.Field];
+}
+
+table MachException {
+    type:uint32;
+    code:uint64;
+    subcode:uint64;
+}
+
+table PosixSignal {
+    number:int32;
+    name:string;
+    code:int32;
+    code_name:string;
+    errno:int32;
+    has_fault_address:bool;
+    fault_address:uint64;
+}
+
+// Apple specific information that accompanies a crash but is not represented
+// by Mach or POSIX exception fields (e.g. Watchdog kills)
+table AppleTermination {
+    // The Apple termination domain, such as RBSTerminateContext's domain (10)
+    domain:string;
+
+    // The termination code or well-known subtype (e.g. 0x8BADF00D)
+    code:string;
+
+    // The raw explanation string emitted by the platform for this termination
+    // (e.g. Failed to terminate gracefully after 5.0s)
+    explanation:string;
+
+    // The visibility state of the process at termination time, if reported
+    process_visibility:string;
+
+    // The process state at termination time, if reported (most of the times is Running)
+    process_state:string;
+
+    // The watchdog event name (process-exit, scene-update)
+    watchdog_event:string;
+
+    // The watchdog visibility classification (Foreground, Background, Unkown)
+    watchdog_visibility:string;
+}
+
+// Apple-specific crash facts. A reporter may provide more than one of these
+// fields for a single crash observation
+table AppleCrashDetails {
+    nsexception:NSException;
+    mach_exception:MachException;
+    posix_signal:PosixSignal;
+    termination:AppleTermination;
+}
+
+table AndroidCrashDetails {
+    // TBD
+}
+
+union CrashInfoDetails {
+    AppleCrashDetails,
+    AndroidCrashDetails,
+}
+
+// Evidence captured about one crash by one reporter. Report.errors remains a
+// compatibility summary; this table is the source of complete crash facts.
+table CrashInfo {
+    // Whether the reporter captured this crash from within the crashing process
+    // or from an external observer
+    reporter_scope:CrashReporterScope;
+
+    // The concrete implementation that produced this crash info entry
+    reporter:CrashReporter;
+
+    // The time at which this reporter observed or recorded the crash
+    occurred_at:Timestamp;
+
+    // Reporter-specific crash payload information
+    details:CrashInfoDetails;
+
+    // Thread state captured by this reporter. This may differ from the legacy
+    // report-level thread_details and from other crash_info entries
+    thread_details:ThreadDetails;
+}
+
 table BinaryImage {
     // identifier for the compiled binary - corresponds to Frame.image_id
     id:string;
@@ -443,6 +547,9 @@ table Report {
 
     // Additional information added to the report during server-side processing.
     processing_result:ProcessingResult;
+
+    // Complete source-specific crash evidence
+    crash_info:[CrashInfo];
 }
 
 root_type Report;

--- a/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
+++ b/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
@@ -450,58 +450,8 @@ table AppleCrashDetails {
     termination:AppleTermination;
 }
 
-// JVM exception information captured by Android's uncaught exception handling
-table AndroidJVMCrash {
-    // The Java/Kotlin exception chain associated with the crash.
-    exceptions:[Error];
-}
-
-// Native Android crash information captured from tombstones or equivalent
-// crash-reporting sources
-table AndroidNativeCrash {
-    // The terminating signal, if one was reported for the native crash
-    signal:PosixSignal;
-
-    // The native abort message, if one was emitted by the runtime
-    abort_message:string;
-
-    // Additional native crash causes or summaries emitted by the platform
-    causes:[string];
-}
-
-// Android StrictMode violation information captured when the SDK reports a
-// StrictMode issue.
-table AndroidStrictModeViolation {
-    // The StrictMode policy in effect when the violation occurred
-    policy:string;
-
-    // The violation class/category reported by StrictMode
-    violation_type:string;
-
-    // The message or summary associated with the violation
-    message:string;
-}
-
-// Android ANR information captured from ANR diagnostics or equivalent sources
-table AndroidAnr {
-    // The platform-reported ANR reason or category
-    reason:string;
-
-    // The activity or component implicated in the ANR, if reported
-    activity:string;
-
-    // The process/app state associated with the ANR
-    state:string;
-
-    // The ANR explanation or message provided by the platform
-    message:string;
-}
-
 table AndroidCrashDetails {
-    jvm:AndroidJVMCrash;
-    native:AndroidNativeCrash;
-    strict_mode:AndroidStrictModeViolation;
-    anr:AndroidAnr;
+    // TBD: Android crash/error structure still needs to be defined.
 }
 
 union CrashInfoDetails {


### PR DESCRIPTION
# Overview
The idea is to keep as much raw crash data as possible instead of forcing the SDK to decide on a final interpretation too early. This is important because different reporters can provide different information about the same crash, and we should have/expose that data. Having all of it gives the backend more flexibility later for grouping, display, workflows, and future logic changes without needing SDK changes again.