### PR TITLE
[BIT-9016] Remove AndroidCrashDetails

### DIFF
--- a/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
+++ b/src/bitdrift_public/fbs/issue-reporting/v1/report.fbs
@@ -450,13 +450,10 @@ table AppleCrashDetails {
     termination:AppleTermination;
 }
 
-table AndroidCrashDetails {
-    // TBD: Android crash/error structure still needs to be defined.
-}
-
+// Android crash details are intentionally not modeled yet. The optimal
+// structure and set of crash/error sources still need to be defined.
 union CrashInfoDetails {
     AppleCrashDetails,
-    AndroidCrashDetails,
 }
 
 // Evidence captured about one crash by one reporter. Report.errors remains a


### PR DESCRIPTION
# Overview
Related to this [other PR](https://github.com/bitdriftlabs/api/pull/181)

This PR removes the `AndroidCrashDetails`; keeping an empty Android type was causing issues in downstream code generation, so seems its better to leave Android out of the schema entirely until we define the right shape and sources there.