### PR TITLE
workflows: add report handoff API

### DIFF
--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -380,6 +380,9 @@ message UploadArtifactRequest {
 
   // The set of feature flags that were active at the time of artifact emission.
   repeated FeatureFlag feature_flags = 8;
+
+  // Client workflow continuations that should be evaluated when this crash report is processed.
+  optional workflow.v1.WorkflowCrashHandoff workflow_crash_handoff = 9;
 }
 
 message UploadArtifactResponse {

--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -382,6 +382,7 @@ message UploadArtifactRequest {
   repeated FeatureFlag feature_flags = 8;
 
   // Client workflow continuations that should be evaluated when this report is processed.
+  // Only populated for issue-report artifacts; other artifact types must leave this unset.
   optional workflow.v1.WorkflowReportHandoff workflow_report_handoff = 9;
 }
 

--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -381,7 +381,7 @@ message UploadArtifactRequest {
   // The set of feature flags that were active at the time of artifact emission.
   repeated FeatureFlag feature_flags = 8;
 
-  // Client workflow continuations that should be evaluated when this crash report is processed.
+  // Client workflow continuations that should be evaluated when this crash report is processed. This is only set for crash reports.
   optional workflow.v1.WorkflowCrashHandoff workflow_crash_handoff = 9;
 }
 

--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -381,8 +381,8 @@ message UploadArtifactRequest {
   // The set of feature flags that were active at the time of artifact emission.
   repeated FeatureFlag feature_flags = 8;
 
-  // Client workflow continuations that should be evaluated when this crash report is processed. This is only set for crash reports.
-  optional workflow.v1.WorkflowCrashHandoff workflow_crash_handoff = 9;
+  // Client workflow continuations that should be evaluated when this report is processed.
+  optional workflow.v1.WorkflowReportHandoff workflow_report_handoff = 9;
 }
 
 message UploadArtifactResponse {

--- a/src/bitdrift_public/protobuf/client/v1/artifact.proto
+++ b/src/bitdrift_public/protobuf/client/v1/artifact.proto
@@ -50,8 +50,8 @@ message ArtifactUploadIndex {
     // The storage format of the artifact, which determines whether we apply checksum validation during processing.
     StorageFormat storage_format = 9;
 
-    // Client workflow continuations that should be evaluated when a crash report is processed. This is only set for crash artifacts.
-    optional bitdrift_public.protobuf.workflow.v1.WorkflowCrashHandoff workflow_crash_handoff = 10;
+    // Client workflow continuations that should be evaluated when this report is processed.
+    optional bitdrift_public.protobuf.workflow.v1.WorkflowReportHandoff workflow_report_handoff = 10;
   }
 
   // List of files, in order of time, that are pending upload.

--- a/src/bitdrift_public/protobuf/client/v1/artifact.proto
+++ b/src/bitdrift_public/protobuf/client/v1/artifact.proto
@@ -11,6 +11,7 @@ package bitdrift_public.protobuf.client.v1;
 
 import "bitdrift_public/protobuf/client/v1/feature_flag.proto";
 import "bitdrift_public/protobuf/logging/v1/payload.proto";
+import "bitdrift_public/protobuf/workflow/v1/workflow.proto";
 import "google/protobuf/timestamp.proto";
 
 enum StorageFormat {
@@ -48,6 +49,9 @@ message ArtifactUploadIndex {
 
     // The storage format of the artifact, which determines whether we apply checksum validation during processing.
     StorageFormat storage_format = 9;
+
+    // Client workflow continuations that should be evaluated when a crash report is processed. This is only set for crash artifacts.
+    optional bitdrift_public.protobuf.workflow.v1.WorkflowCrashHandoff workflow_crash_handoff = 10;
   }
 
   // List of files, in order of time, that are pending upload.

--- a/src/bitdrift_public/protobuf/client/v1/artifact.proto
+++ b/src/bitdrift_public/protobuf/client/v1/artifact.proto
@@ -51,6 +51,7 @@ message ArtifactUploadIndex {
     StorageFormat storage_format = 9;
 
     // Client workflow continuations that should be evaluated when this report is processed.
+    // Only populated for issue-report artifacts; other artifact types must leave this unset.
     optional bitdrift_public.protobuf.workflow.v1.WorkflowReportHandoff workflow_report_handoff = 10;
   }
 

--- a/src/bitdrift_public/protobuf/workflow/v1/workflow.proto
+++ b/src/bitdrift_public/protobuf/workflow/v1/workflow.proto
@@ -23,23 +23,23 @@ message WorkflowsConfiguration {
   repeated Workflow workflows = 1;
 }
 
-// The state needed to continue a client workflow when a crash report is processed by the server.
-// Only workflows currently waiting on an OnCrash transition are included.
-message WorkflowCrashHandoff {
-  repeated WorkflowCrashContinuation continuations = 1;
+// The state needed to continue a client workflow when a report is processed by the server.
+// Only workflows currently waiting on an OnReport transition are included.
+message WorkflowReportHandoff {
+  repeated WorkflowReportContinuation continuations = 1;
 }
 
-// A single client workflow with one or more waiting crash continuations.
-message WorkflowCrashContinuation {
-  // The canonical hash and ID of the delivered client workflow configuration.
-  string client_workflow_id = 1 [(validate.rules).string = {min_len: 1}];
+// A terminal IssueMatch rule with one or more waiting client continuations.
+message WorkflowReportContinuation {
+  // The canonical V3 rule hash of the terminal IssueMatch.
+  string issue_match_rule_hash = 1 [(validate.rules).string = {min_len: 1}];
 
-  // State extracted by preceding client workflow steps and consumed by the terminal crash action.
-  repeated CrashTraversalContext traversals = 2 [(validate.rules).repeated = {min_items: 1}];
+  // State extracted by preceding client workflow steps and consumed by the terminal report action.
+  repeated ReportTraversalContext traversals = 2 [(validate.rules).repeated = {min_items: 1}];
 }
 
-// State retained for a traversal that is waiting for an OnCrash transition.
-message CrashTraversalContext {
+// State retained for a traversal that is waiting for an OnReport transition.
+message ReportTraversalContext {
   map<string, string> extracted_fields = 1;
   map<string, google.protobuf.Timestamp> extracted_timestamps = 2;
 }
@@ -141,11 +141,18 @@ message Workflow {
       RuleStateChangeMatch rule_state_change_match = 3;
       // This will match when a new session starts.
       bool on_new_session = 4;
-      // This will match when a crash report is enqueued.
-      bool on_crash = 5;
+      // This will match when a report is processed.
+      OnReport on_report = 5;
     }
 
     reserved 2;
+  }
+
+  // A terminal transition that delegates IssueMatch evaluation to the server when a report is
+  // processed. The rule hash associates this client prefix with every matching server-side
+  // IssueMatch configuration.
+  message OnReport {
+    string issue_match_rule_hash = 1 [(validate.rules).string = {min_len: 1}];
   }
 
   // An extra configuration for a given transition.

--- a/src/bitdrift_public/protobuf/workflow/v1/workflow.proto
+++ b/src/bitdrift_public/protobuf/workflow/v1/workflow.proto
@@ -13,6 +13,7 @@ import "bitdrift_public/protobuf/matcher/v1/log_matcher.proto";
 import "bitdrift_public/protobuf/state/v1/matcher.proto";
 import "bitdrift_public/protobuf/state/v1/scope.proto";
 import "bitdrift_public/protobuf/workflow/v1/save_field.proto";
+import "google/protobuf/timestamp.proto";
 import "validate/validate.proto";
 
 // The wrapper for the list of workflows. Top-level item used to send information
@@ -20,6 +21,27 @@ import "validate/validate.proto";
 message WorkflowsConfiguration {
   // An optional list of workflows.
   repeated Workflow workflows = 1;
+}
+
+// The state needed to continue a client workflow when a crash report is processed by the server.
+// Only workflows currently waiting on an OnCrash transition are included.
+message WorkflowCrashHandoff {
+  repeated WorkflowCrashContinuation continuations = 1;
+}
+
+// A single client workflow with one or more waiting crash continuations.
+message WorkflowCrashContinuation {
+  // The canonical hash and ID of the delivered client workflow configuration.
+  string client_workflow_id = 1 [(validate.rules).string = {min_len: 1}];
+
+  // State extracted by preceding client workflow steps and consumed by the terminal crash action.
+  repeated CrashTraversalContext traversals = 2 [(validate.rules).repeated = {min_items: 1}];
+}
+
+// State retained for a traversal that is waiting for an OnCrash transition.
+message CrashTraversalContext {
+  map<string, string> extracted_fields = 1;
+  map<string, google.protobuf.Timestamp> extracted_timestamps = 2;
 }
 
 // Extracts multiple state entries and turns each match into a separate output item with two
@@ -119,6 +141,8 @@ message Workflow {
       RuleStateChangeMatch rule_state_change_match = 3;
       // This will match when a new session starts.
       bool on_new_session = 4;
+      // This will match when a crash report is enqueued.
+      bool on_crash = 5;
     }
 
     reserved 2;


### PR DESCRIPTION
Adds the typed report-handoff contract used to resume multi-step IssueMatch workflows on the server.

The client prefix ends in typed OnReport, keyed by the terminal IssueMatch rule hash. Artifact index and upload messages carry WorkflowReportHandoff, grouped by that hash with saved traversal field and timestamp context.