### PR TITLE
various client stats changes

### DIFF
--- a/src/bitdrift_public/protobuf/client/v1/api.proto
+++ b/src/bitdrift_public/protobuf/client/v1/api.proto
@@ -80,6 +80,28 @@ message StateUpdateRequest {
 
 // The initial request sent over the stream.
 message HandshakeRequest {
+  // Connection and stats pipeline analytics that are independent of the stats payload itself.
+  message Analytics {
+    // A durable stats-pipeline analytics report. The client resends it until the server accepts
+    // its stable ID, then starts accumulating the next report.
+    message StatsPipelineAnalyticsReport {
+      // Stable ID used by the server to deduplicate this ACK-reset report.
+      string report_id = 1;
+
+      // The ACK-reset counters for this report. This is also the durable on-disk representation,
+      // so storage and the handshake cannot diverge as counters are added.
+      StatsPipelineAnalytics analytics = 2;
+    }
+
+    // The number of handshake attempts since this client process started. This counter starts at
+    // one and is not persisted across process restarts.
+    uint64 connection_count_since_process_start = 1;
+
+    // Durable ACK-reset stats pipeline analytics. The server must deduplicate report_id before
+    // adding the counters to its totals and echo the ID in HandshakeResponse when accepted.
+    StatsPipelineAnalyticsReport stats_pipeline = 2;
+  }
+
   // A set of opaque metadata that identifies the connecting device. These will
   // remain static for the duration of this stream.
   // TODO(snowp): Support updating these throughout the session / move to StateUpdateRequest.
@@ -118,6 +140,14 @@ message HandshakeRequest {
   // multiple sessions included if some session transitions have happened while offline and have
   // not yet been sent to the server.
   StateUpdateRequest state_update = 9;
+
+  // Connection and stats pipeline analytics.
+  Analytics analytics = 10;
+
+  // A pending stats upload selected during client initialization. The server acknowledges it in a
+  // StatsUploadResponse after the handshake, allowing the client to avoid an additional
+  // request/response round trip before deleting the persisted source files.
+  StatsUploadRequest startup_stats_upload = 11;
 }
 
 // Notifies the server about the intent to upload one or more batches of logs. The client is expected (but
@@ -396,6 +426,12 @@ message UploadArtifactResponse {
 
 // The response sent as part of stream establishment.
 message HandshakeResponse {
+  message AnalyticsAck {
+    // The analytics report ID from HandshakeRequest.Analytics.StatsPipelineAnalytics that the
+    // server accepted. The client retains the report until this ID is echoed back.
+    string report_id = 1;
+  }
+
   message StreamSettings {
     // How often the client should ping the server. This informs the client how
     // often a ping request should be issued over the newly created stream.
@@ -420,6 +456,10 @@ message HandshakeResponse {
   // If set, the client should update or clear the corresponding state according to the provided
   // list of updates.
   repeated ClientStateUpdate client_state_updates = 4;
+
+  // The acknowledgement for the durable stats pipeline analytics report. If absent, the client
+  // resends the same report ID during its next handshake.
+  AnalyticsAck analytics_ack = 5;
 }
 
 // A general indication of rate limiting from server to client.

--- a/src/bitdrift_public/protobuf/client/v1/metric.proto
+++ b/src/bitdrift_public/protobuf/client/v1/metric.proto
@@ -12,6 +12,38 @@ package bitdrift_public.protobuf.client.v1;
 import "google/protobuf/timestamp.proto";
 import "validate/validate.proto";
 
+// Durable ACK-reset analytics accumulated while stats files are managed on disk. A client seals
+// these counters into a report during the handshake and retains that report until the server
+// acknowledges its stable ID.
+message StatsPipelineAnalytics {
+  // Number of stats upload payloads acknowledged successfully since the prior accepted analytics
+  // report. This can be reconciled directly with received stats upload payloads.
+  uint64 stats_uploads_acknowledged_successfully = 1;
+
+  // Number of stats upload payloads acknowledged unsuccessfully since the prior accepted
+  // analytics report.
+  uint64 stats_uploads_acknowledged_unsuccessfully = 2;
+
+  // Number of persisted stats files dropped because standard rotation reached the configured
+  // maximum number of aggregated files.
+  uint64 stats_files_dropped_due_to_rotation = 3;
+
+  // Number of active stats snapshot files dropped because their on-disk contents could not be
+  // read while preparing to merge a new snapshot.
+  uint64 stats_files_dropped_due_to_active_snapshot_corruption = 4;
+
+  // Number of pending stats snapshot files dropped because their on-disk contents could not be
+  // read while preparing an upload.
+  uint64 stats_files_dropped_due_to_pending_snapshot_corruption = 5;
+
+  // Number of persisted stats snapshot files dropped when recovering from a corrupt or unreadable
+  // aggregation index.
+  uint64 stats_files_dropped_due_to_index_recovery = 6;
+
+  // Number of aggregation-index recovery events that discarded an existing stats directory.
+  uint64 stats_index_recovery_events = 7;
+}
+
 // Used to track an index of pending aggregations that need to be uploaded. This is used by the
 // file manager to coordinate merging and uploads.
 message PendingAggregationIndex {
@@ -25,8 +57,21 @@ message PendingAggregationIndex {
     // indicates that the file is ready for upload.
     google.protobuf.Timestamp period_end = 3;
   }
+
+  // A sealed analytics report retained until the server acknowledges its stable identifier.
+  message PendingStatsPipelineAnalyticsReport {
+    string report_id = 1;
+    StatsPipelineAnalytics analytics = 2;
+  }
+
   // List of files, in order of period_start, that are pending upload.
   repeated PendingFile pending_files = 1;
+
+  // Analytics that have not yet been moved into a report for a handshake.
+  StatsPipelineAnalytics unreported_stats_pipeline_analytics = 2;
+
+  // Analytics report currently awaiting a server acknowledgement.
+  PendingStatsPipelineAnalyticsReport pending_stats_pipeline_analytics_report = 3;
 }
 
 message Counter {


### PR DESCRIPTION
1) Allow sending historical metrics during the handshake to avoid a
   round trip and make it more likely that they get uploaded.
2) Add substantial analytics that are also sent as part of the handshake
   on overall system performance. This is kept out of the stats system
   to avoid circular deps.
3) Add a per-process connection count index to allow better
   understanding if initial connection performance.